### PR TITLE
feat(mac): show hidden files in Finder

### DIFF
--- a/.config/yadm/bootstrap.d/002-mac.sh
+++ b/.config/yadm/bootstrap.d/002-mac.sh
@@ -13,6 +13,9 @@ defaults write NSGlobalDomain NSAutomaticDashSubstitutionEnabled -bool false
 # Smart Quotes in Messages
 defaults write com.apple.messageshelper.MessageController SOInputLineSettings -dict-add "automaticQuoteSubstitutionEnabled" -bool false
 
+# Show hidden files in Finder
+defaults write com.apple.finder AppleShowAllFiles -bool true
+
 #Enable Web Dev Tools in Safari (Useful!)
 defaults write com.apple.Safari IncludeDevelopMenu -bool true
 defaults write com.apple.Safari IncludeInternalDebugMenu -bool true


### PR DESCRIPTION
Closes #4

Adds `defaults write com.apple.finder AppleShowAllFiles -bool true` to the macOS bootstrap script.